### PR TITLE
コンポーネントの密結合の解消

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // App.js
 import React from "react";
-import ShogiBoard from "./shougi_AI.jsx";
+import ShogiContent from "./shougi_AI.jsx";
 
 const App = () => {
 	return (
@@ -14,7 +14,7 @@ const App = () => {
 			}}
 		>
 			<h1>将棋盤</h1>
-			<ShogiBoard />
+			<ShogiContent />
 		</div>
 	);
 };

--- a/src/Shougi_AI.css
+++ b/src/Shougi_AI.css
@@ -17,6 +17,7 @@
 	width: 100vw;
 	height: 90vh;
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
 	margin: 0;

--- a/src/components/HandSummary.jsx
+++ b/src/components/HandSummary.jsx
@@ -1,0 +1,25 @@
+import styles from "./HandSummary.module.css";
+import PieceImage from "./PieceImage";
+
+const HandSummary = ({ pieces, selected, onPieceClick }) => {
+	const hand = pieces.reduce((acc, piece) => {
+		acc[piece] = (acc[piece] || 0) + 1;
+		return acc;
+	}, {});
+
+	return (
+		<div className={styles["hand-summary-container"]}>
+			{Object.entries(hand).map(([piece, count]) => (
+				<PieceImage
+					key={piece}
+					piece={piece.toLowerCase()}
+					count={count}
+					highlight={piece === selected}
+					onClick={() => onPieceClick(piece)}
+				/>
+			))}
+		</div>
+	);
+};
+
+export default HandSummary;

--- a/src/components/HandSummary.module.css
+++ b/src/components/HandSummary.module.css
@@ -1,0 +1,6 @@
+.hand-summary-container {
+	display: flex;
+	flex-direction: row;
+	align-items: left;
+	width: 100%;
+}

--- a/src/components/PieceImage.jsx
+++ b/src/components/PieceImage.jsx
@@ -1,7 +1,44 @@
 import styles from "./PieceImage.module.css";
 
-const PieceImage = ({ src }) => {
-	return <img className={styles["piece-image"]} src={src} alt="piece" />;
+const pieceToSrc = {
+	p: "/pieces/p.png",
+	l: "/pieces/l.png",
+	n: "/pieces/n.png",
+	s: "/pieces/s.png",
+	g: "/pieces/g.png",
+	k: "/pieces/k.png",
+	r: "/pieces/r.png",
+	b: "/pieces/b.png",
+	"+p": "/pieces/+p.png",
+	"+l": "/pieces/+l.png",
+	"+n": "/pieces/+n.png",
+	"+s": "/pieces/+s.png",
+	"+r": "/pieces/+r.png",
+	"+b": "/pieces/+b.png",
+};
+
+const PieceImage = ({
+	piece,
+	reverse = false,
+	count = 1,
+	highlight = false,
+	onClick,
+}) => {
+	return (
+		<div
+			className={`${styles["piece-container"]} ${highlight ? styles["piece-highlight"] : ""}`}
+			onClick={onClick}
+			onKeyDown={onClick}
+		>
+			<img
+				className={styles["piece-image"]}
+				src={pieceToSrc[piece]}
+				alt={piece}
+				style={{ transform: reverse ? "rotate(180deg)" : "" }}
+			/>
+			{count > 1 && <span className={styles["piece-number"]}>{count}</span>}
+		</div>
+	);
 };
 
 export default PieceImage;

--- a/src/components/PieceImage.module.css
+++ b/src/components/PieceImage.module.css
@@ -14,6 +14,11 @@
 .piece-image {
 	width: 42px;
 	height: auto;
+	user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	-moz-user-select: none;
+	-webkit-user-drag: none;
 }
 
 .piece-number {

--- a/src/components/PieceImage.module.css
+++ b/src/components/PieceImage.module.css
@@ -1,4 +1,26 @@
+.piece-container {
+	width: 50px;
+	height: 50px;
+	display: flex;
+	position: relative;
+	justify-content: center;
+	align-items: center;
+}
+
+.piece-highlight {
+	background-color: rgba(255, 255, 0, 0.5);
+}
+
 .piece-image {
-	width: 42px; /* 必要に応じてサイズ調整 */
+	width: 42px;
 	height: auto;
+}
+
+.piece-number {
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	-webkit-text-stroke: 1px black;
+	color: white;
+	font-size: x-large;
 }

--- a/src/components/ShogiBoard.jsx
+++ b/src/components/ShogiBoard.jsx
@@ -1,0 +1,44 @@
+import PieceImage from "./PieceImage";
+import styles from "./ShogiBoard.module.css";
+const ShogiBoard = ({ board, selected, onSquareClick, movableCells }) => {
+	console.log(movableCells);
+	return (
+		<div className={styles.board}>
+			{board.map((row, rowIndex) =>
+				row.map((piece, colIndex) => (
+					<Cell
+						// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+						key={`${rowIndex}-${colIndex}`}
+						piece={piece}
+						reverse={piece && piece.toUpperCase() !== piece}
+						selected={selected.row === rowIndex && selected.col === colIndex}
+						onClick={() => onSquareClick(rowIndex, colIndex)}
+						isMovable={movableCells.some(
+							(cell) => cell[0] === rowIndex && cell[1] === colIndex,
+						)}
+					/>
+				)),
+			)}
+		</div>
+	);
+};
+
+const Cell = ({ piece, reverse, selected, onClick, isMovable }) => {
+	return (
+		<div
+			className={`${styles.cell} ${isMovable ? styles.movable : ""}`}
+			onClick={onClick}
+			onKeyDown={onClick}
+		>
+			{piece && (
+				<PieceImage
+					piece={piece.toLowerCase()}
+					reverse={reverse}
+					highlight={selected}
+				/>
+			)}
+		</div>
+	);
+};
+
+export default ShogiBoard;

--- a/src/components/ShogiBoard.module.css
+++ b/src/components/ShogiBoard.module.css
@@ -1,0 +1,29 @@
+.board {
+	display: grid;
+	grid-template-rows: repeat(9, 50px);
+	grid-template-columns: repeat(9, 50px);
+	gap: 0.5px;
+	justify-items: center;
+	align-items: center;
+}
+
+.cell {
+	width: 50px;
+	height: 50px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 20px;
+	color: black;
+	border: 1px solid black;
+	cursor: pointer;
+	background-color: gray;
+
+	&:hover {
+		background-color: rgb(133, 160, 159);
+	}
+}
+
+.movable {
+	background-color: rgb(113, 177, 174);
+}

--- a/src/shougi_AI.jsx
+++ b/src/shougi_AI.jsx
@@ -1,38 +1,9 @@
 import axios from "axios";
 import React, { useState, useEffect, useMemo } from "react";
 import "./Shougi_AI.css";
+import HandSummary from "./components/HandSummary";
 import PieceImage from "./components/PieceImage";
-
-const pieceSymbols = {
-	p: <PieceImage src="/pieces/p.png" />,
-	l: <PieceImage src="/pieces/l.png" />,
-	n: <PieceImage src="/pieces/n.png" />,
-	s: <PieceImage src="/pieces/s.png" />,
-	g: <PieceImage src="/pieces/g.png" />,
-	k: <PieceImage src="/pieces/k.png" />,
-	r: <PieceImage src="/pieces/r.png" />,
-	b: <PieceImage src="/pieces/b.png" />,
-	"+p": <PieceImage src="/pieces/+p.png" />,
-	"+l": <PieceImage src="/pieces/+l.png" />,
-	"+n": <PieceImage src="/pieces/+n.png" />,
-	"+s": <PieceImage src="/pieces/+s.png" />,
-	"+r": <PieceImage src="/pieces/+r.png" />,
-	"+b": <PieceImage src="/pieces/+b.png" />,
-	P: <PieceImage src="/pieces/p.png" />,
-	L: <PieceImage src="/pieces/l.png" />,
-	N: <PieceImage src="/pieces/n.png" />,
-	S: <PieceImage src="/pieces/s.png" />,
-	G: <PieceImage src="/pieces/g.png" />,
-	K: <PieceImage src="/pieces/k.png" />,
-	R: <PieceImage src="/pieces/r.png" />,
-	B: <PieceImage src="/pieces/b.png" />,
-	"+P": <PieceImage src="/pieces/+p.png" />,
-	"+L": <PieceImage src="/pieces/+l.png" />,
-	"+N": <PieceImage src="/pieces/+n.png" />,
-	"+S": <PieceImage src="/pieces/+s.png" />,
-	"+R": <PieceImage src="/pieces/+r.png" />,
-	"+B": <PieceImage src="/pieces/+b.png" />,
-};
+import { removeFirstMatch } from "./utils";
 
 const sfenToNewBoard = (sfen) => {
 	if (sfen === "None") {
@@ -147,11 +118,15 @@ const sfenString =
 const ShogiBoard = () => {
 	const [board, setBoard] = useState(parseSfen(initialSfen));
 	// const [currentSfen, setCurrentSfen] = useState(initialSfen); // SFEN を保持
-	const [selectedPiece, setSelectedPiece] = useState(null);
+	const [selected, setSelected] = useState({
+		type: null, // "board" | "hand" | null
+		piece: null, // string | null
+		row: null, // 0-8 | null
+		col: null, // 0-8 | null
+	});
 	const [turn, setTurn] = useState("w");
 	const [highlightedCells, setHighlightedCells] = useState([]);
 	const [hand, setHand] = useState({ b: [], w: [] }); // 持ち駒を管理
-	const [selectedHandPiece, setSelectedHandPiece] = useState(null); // 持ち駒を選択
 	const [getMessage, setGetMessage] = useState("");
 	const [postMessage, setPostMessage] = useState(""); // サーバから受け取る用
 	const [input, setInput] = useState("");
@@ -178,7 +153,7 @@ const ShogiBoard = () => {
 	const sendData = async () => {
 		//SFEN送信
 		try {
-			const response = await axios.post("http://127.0.0.1:5000/api/data", {
+			const response = await axios.post("http://127.0.0.1:8000/next", {
 				currentSfen,
 			});
 			console.log("Response message:", response.data.response_message);
@@ -222,118 +197,128 @@ const ShogiBoard = () => {
 			setIsGameOver(true);
 		}
 		if (isGameOver) return;
-		if (selectedHandPiece !== null) {
-			if (!board[row][col]) {
-				const newBoard = board.map((r) => r.slice());
-				newBoard[row][col] = selectedHandPiece.piece;
-				setBoard(newBoard);
-
-				setHand((prev) => {
-					const updatedHand = { ...prev };
-					updatedHand[turn] = prev[turn].filter(
-						(_, index) => index !== selectedHandPiece.index,
-					);
-
-					return updatedHand;
-				});
-
-				setSelectedHandPiece(null);
-				setTurn(turn === "b" ? "w" : "b");
-				setTurnCount((prev) => prev + 1);
-			} else {
-				setSelectedHandPiece(null);
-			}
-			return;
-		}
 
 		const piece = board[row][col];
+		switch (selected.type) {
+			// 現時点でボード上の駒が選択されている場合
+			case "board": {
+				const { row: fromRow, col: fromCol } = selected;
+				const movable = highlightedCells.some(
+					([r, c]) => r === row && c === col,
+				);
 
-		if (selectedPiece) {
-			const [fromRow, fromCol] = selectedPiece;
-			const movable = highlightedCells.some(([r, c]) => r === row && c === col);
+				// 移動可能マスをクリックした場合
+				if (movable) {
+					const newBoard = board.map((r) => r.slice());
+					const movingPiece = newBoard[fromRow][fromCol];
+					const isEnemy = isEnemyPiece(piece, turn);
 
-			if (movable) {
-				const newBoard = board.map((r) => r.slice());
-				const movingPiece = newBoard[fromRow][fromCol];
-				const isEnemy = isEnemyPiece(piece, turn);
-
-				if (isEnemy) {
-					if (piece === "k" || piece === "K") {
-						// 王または玉が取られた場合、ゲーム終了
-						alert(`${turn === "b" ? "βらm" : "あなた"}の勝利です！`);
-						setIsGameOver(true);
-						return;
-					}
-					setHand((prev) => {
-						const updatedHand = { ...prev };
-						const originalPiece = piece.startsWith("+")
-							? piece.slice(1)
-							: piece; // 成駒を元の駒に戻す
-						if (turn === "b") {
-							updatedHand.b = [...prev.b, originalPiece.toLowerCase()];
-						} else if (turn === "w") {
-							updatedHand.w = [...prev.w, originalPiece.toUpperCase()];
+					if (isEnemy) {
+						if (piece === "k" || piece === "K") {
+							// 王または玉が取られた場合、ゲーム終了
+							alert(`${turn === "b" ? "βらm" : "あなた"}の勝利です！`);
+							setIsGameOver(true);
+							return;
 						}
-						setHand(updatedHand);
-						return updatedHand;
-					});
-				}
+						setHand((prev) => {
+							const updatedHand = { ...prev };
+							const originalPiece = piece.startsWith("+")
+								? piece.slice(1)
+								: piece; // 成駒を元の駒に戻す
+							if (turn === "b") {
+								updatedHand.b = [...prev.b, originalPiece.toLowerCase()];
+							} else if (turn === "w") {
+								updatedHand.w = [...prev.w, originalPiece.toUpperCase()];
+							}
+							setHand(updatedHand);
+							return updatedHand;
+						});
+					}
 
-				const isPromotable = [
-					"p",
-					"l",
-					"n",
-					"s",
-					"r",
-					"b",
-					"P",
-					"L",
-					"N",
-					"S",
-					"R",
-					"B",
-				].includes(movingPiece);
-				const enteredEnemyTerritory =
-					(turn === "w" && (fromRow <= 2 || row <= 2)) ||
-					(turn === "b" && (fromRow >= 6 || row >= 6));
+					const isPromotable = [
+						"p",
+						"l",
+						"n",
+						"s",
+						"r",
+						"b",
+						"P",
+						"L",
+						"N",
+						"S",
+						"R",
+						"B",
+					].includes(movingPiece);
+					const enteredEnemyTerritory =
+						(turn === "w" && (fromRow <= 2 || row <= 2)) ||
+						(turn === "b" && (fromRow >= 6 || row >= 6));
 
-				if (isPromotable && enteredEnemyTerritory) {
-					if (window.confirm("成りますか？")) {
-						newBoard[row][col] = promotePiece(movingPiece);
+					if (isPromotable && enteredEnemyTerritory) {
+						if (window.confirm("成りますか？")) {
+							newBoard[row][col] = promotePiece(movingPiece);
+						} else {
+							newBoard[row][col] = movingPiece;
+						}
 					} else {
 						newBoard[row][col] = movingPiece;
 					}
+
+					newBoard[fromRow][fromCol] = null;
+
+					setBoard(newBoard);
+					setSelected({ type: null, piece: null, row: null, col: null });
+					setHighlightedCells([]);
+					setTurn(turn === "b" ? "w" : "b");
+					setTurnCount((prev) => prev + 1);
+
+					//setCurrentSfen(generateSfen(newBoard, hand, turn, turnCount));  // SFEN を更新
 				} else {
-					newBoard[row][col] = movingPiece;
+					setSelected({ type: null, piece: null, row: null, col: null });
+					setHighlightedCells([]);
+					setCurrentSfen(generateSfen(board, hand, turn, turnCount));
 				}
+				break;
+			}
 
-				newBoard[fromRow][fromCol] = null;
-
+			// 現時点で持ち駒が選択されている場合
+			case "hand": {
+				// 既に駒がある場合は何もしない
+				if (piece) {
+					setSelected({ type: null, piece: null, row: null, col: null });
+					break;
+				}
+				// 空いている場合は駒を配置する
+				const newBoard = board.map((r) => r.slice());
+				newBoard[row][col] = selected.piece;
 				setBoard(newBoard);
-				setSelectedPiece(null);
-				setHighlightedCells([]);
+				setHand((prev) => ({
+					...prev,
+					[turn]: removeFirstMatch(prev[turn], selected.piece),
+				}));
+				setSelected({ type: null, piece: null, row: null, col: null });
 				setTurn(turn === "b" ? "w" : "b");
 				setTurnCount((prev) => prev + 1);
-
-				//setCurrentSfen(generateSfen(newBoard, hand, turn, turnCount));  // SFEN を更新
-			} else {
-				setSelectedPiece(null);
-				setHighlightedCells([]);
-				setCurrentSfen(generateSfen(board, hand, turn, turnCount));
+				break;
 			}
-		} else if (isOwnPiece(piece, turn)) {
-			setSelectedPiece([row, col]);
-			setHighlightedCells(getMovableCells(row, col, piece));
-			setCurrentSfen(generateSfen(board, hand, turn, turnCount));
+			// 現時点で何も選択されていない場合
+
+			default: {
+				if (isOwnPiece(board[row][col], turn)) {
+					setSelected({ type: "board", piece, row, col });
+					setHighlightedCells(getMovableCells(row, col, piece));
+					setCurrentSfen(generateSfen(board, hand, turn, turnCount));
+				}
+				break;
+			}
 		}
 	};
 
-	const handleHandClick = (piece, index) => {
+	const handleHandClick = (piece) => {
 		if (
 			(turn === "b" && piece === piece.toLowerCase()) ||
 			(turn === "w" && piece === piece.toUpperCase())
 		) {
-			setSelectedHandPiece({ piece, index });
+			setSelected({ type: "hand", piece, row: null, col: null });
 		}
 	};
 
@@ -568,24 +553,12 @@ const ShogiBoard = () => {
 		<div className="cite_style">
 			{/* 先手の持ち駒 */}
 			<div className="container-bram">
-				<p>　　　　　　　　　　　　　　　　αらm:</p>
-				<div className="hand-wrapper-bram">
-					{hand.b.map((piece, index) => (
-						<div
-							key={`b-${
-								// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-								index
-							}`}
-							onClick={() => handleHandClick(piece, index)}
-							onKeyDown={() => handleHandClick(piece, index)}
-							className={`hand-piece-bram ${
-								turn === "b" ? "enabled" : "disabled"
-							} ${turn === "b" && selectedHandPiece?.index === index ? "selected" : ""}`}
-						>
-							{pieceSymbols[piece]}
-						</div>
-					))}
-				</div>
+				{/* <p>　　　　　　　　　　　　　　　　αらm:</p> */}
+				<HandSummary
+					pieces={hand.b}
+					onPieceClick={handleHandClick}
+					selected={selected.type === "hand" ? selected.piece : null}
+				/>
 			</div>
 
 			{/* 将棋盤 */}
@@ -596,9 +569,7 @@ const ShogiBoard = () => {
 							([r, c]) => r === rowIndex && c === colIndex,
 						);
 						const isSelected =
-							selectedPiece &&
-							selectedPiece[0] === rowIndex &&
-							selectedPiece[1] === colIndex;
+							selected.row === rowIndex && selected.col === colIndex;
 						const isRotated = piece && piece.toLowerCase() === piece;
 
 						return (
@@ -611,9 +582,13 @@ const ShogiBoard = () => {
 								onKeyDown={() => sepa_turn(rowIndex, colIndex)}
 								className={`cell ${isHighlighted ? "highlighted" : ""} ${
 									isSelected ? "selected" : ""
-								} ${isRotated ? "rotated" : ""}`}
+								}`}
 							>
-								{piece ? pieceSymbols[piece] : ""}
+								{piece ? (
+									<PieceImage piece={piece.toLowerCase()} reverse={isRotated} />
+								) : (
+									""
+								)}
 							</div>
 						);
 					}),
@@ -622,24 +597,12 @@ const ShogiBoard = () => {
 
 			{/* 後手の持ち駒 */}
 			<div className="container">
-				<p>あなた:</p>
-				<div className="hand-wrapper">
-					{hand.w.map((piece, index) => (
-						<div
-							key={`w-${
-								// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-								index
-							}`}
-							onClick={() => handleHandClick(piece, index)}
-							onKeyDown={() => handleHandClick(piece, index)}
-							className={`hand-piece ${
-								turn === "w" ? "enabled" : "disabled"
-							} ${turn === "w" && selectedHandPiece?.index === index ? "selected" : ""}`}
-						>
-							{pieceSymbols[piece]}
-						</div>
-					))}
-				</div>
+				{/* <p>あなた:</p> */}
+				<HandSummary
+					pieces={hand.w}
+					onPieceClick={handleHandClick}
+					selected={selected.type === "hand" ? selected.piece : null}
+				/>
 			</div>
 		</div>
 	);

--- a/src/shougi_AI.jsx
+++ b/src/shougi_AI.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import "./Shougi_AI.css";
 import HandSummary from "./components/HandSummary";
 import PieceImage from "./components/PieceImage";
+import ShogiBoard from "./components/ShogiBoard";
 import { removeFirstMatch } from "./utils";
 
 const sfenToNewBoard = (sfen) => {
@@ -115,7 +116,7 @@ const initialSfen =
 const sfenString =
 	"lnsgkg1nl/1r5s1/ppp1p2pp/3p5/5PP2/2P6/PP1PP2PP/7R1/LNSGKGSNL b bB2P w - 3";
 
-const ShogiBoard = () => {
+const ShogiContent = () => {
 	const [board, setBoard] = useState(parseSfen(initialSfen));
 	// const [currentSfen, setCurrentSfen] = useState(initialSfen); // SFEN を保持
 	const [selected, setSelected] = useState({
@@ -275,7 +276,7 @@ const ShogiBoard = () => {
 				} else {
 					setSelected({ type: null, piece: null, row: null, col: null });
 					setHighlightedCells([]);
-					setCurrentSfen(generateSfen(board, hand, turn, turnCount));
+					// setCurrentSfen(generateSfen(board, hand, turn, turnCount));
 				}
 				break;
 			}
@@ -305,8 +306,9 @@ const ShogiBoard = () => {
 			default: {
 				if (isOwnPiece(board[row][col], turn)) {
 					setSelected({ type: "board", piece, row, col });
+					console.log(getMovableCells(row, col, piece));
 					setHighlightedCells(getMovableCells(row, col, piece));
-					setCurrentSfen(generateSfen(board, hand, turn, turnCount));
+					// setCurrentSfen(generateSfen(board, hand, turn, turnCount));
 				}
 				break;
 			}
@@ -514,7 +516,6 @@ const ShogiBoard = () => {
 		};
 
 		let num = 0;
-		// (directions[piece] || []).forEach(([dx, dy]) => {
 		for (const [dx, dy] of directions[piece] || []) {
 			num++;
 			let x = row + dx;
@@ -562,38 +563,12 @@ const ShogiBoard = () => {
 			</div>
 
 			{/* 将棋盤 */}
-			<div className="board">
-				{board.map((row, rowIndex) =>
-					row.map((piece, colIndex) => {
-						const isHighlighted = highlightedCells.some(
-							([r, c]) => r === rowIndex && c === colIndex,
-						);
-						const isSelected =
-							selected.row === rowIndex && selected.col === colIndex;
-						const isRotated = piece && piece.toLowerCase() === piece;
-
-						return (
-							<div
-								key={`${rowIndex}-${
-									// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-									colIndex
-								}`}
-								onClick={() => sepa_turn(rowIndex, colIndex)}
-								onKeyDown={() => sepa_turn(rowIndex, colIndex)}
-								className={`cell ${isHighlighted ? "highlighted" : ""} ${
-									isSelected ? "selected" : ""
-								}`}
-							>
-								{piece ? (
-									<PieceImage piece={piece.toLowerCase()} reverse={isRotated} />
-								) : (
-									""
-								)}
-							</div>
-						);
-					}),
-				)}
-			</div>
+			<ShogiBoard
+				board={board}
+				selected={selected}
+				onSquareClick={sepa_turn}
+				movableCells={highlightedCells}
+			/>
 
 			{/* 後手の持ち駒 */}
 			<div className="container">
@@ -608,4 +583,4 @@ const ShogiBoard = () => {
 	);
 };
 
-export default ShogiBoard;
+export default ShogiContent;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export function removeFirstMatch(arr, value) {
+	const index = arr.indexOf(value);
+	if (index === -1) {
+		return arr;
+	}
+	return [...arr.slice(0, index), ...arr.slice(index + 1)];
+}


### PR DESCRIPTION
# 変更点

- 将棋盤コンポーネントを `components/ShogiBoard.jsx` に分離
- 持ち駒コンポーネントを `components/HandSummary.jsx` に分離
- 状態 `selectedPiece`, `selectedHandPiece` を `selected` に集約

# スクリーンショット
<img width="687" alt="image" src="https://github.com/user-attachments/assets/4d3b6972-ae26-4665-a71a-c2f12025b1fb" />

# Issue

- #2 
