### PR TITLE
feat: 先手後手の選択機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:host": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "biome lint",

--- a/src/hooks/useTurn.js
+++ b/src/hooks/useTurn.js
@@ -1,0 +1,10 @@
+import { useLocalStorage } from "react-use";
+import { Color } from "shogi.js";
+
+const initialTrun = Color.Black;
+
+function useTurn() {
+	return useLocalStorage("turn", initialTrun);
+}
+
+export default useTurn;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,13 +1,31 @@
+import { useState } from "react";
 import { useNavigate } from "react-router";
+import { Color } from "shogi.js";
 import useSfen from "../hooks/useSfen";
+import useTurn from "../hooks/useTurn";
 import styles from "./Home.module.css";
+
+const options = [
+	{ value: Color.Black, label: "先手" },
+	{ value: Color.White, label: "後手" },
+	{ value: "random", label: "ランダム" },
+];
 
 const Home = () => {
 	const [sfen, setSfen, resetSfen] = useSfen();
+	const [turn, setTurn] = useTurn();
+	const [selected, setSelected] = useState({
+		turn: Color.Black,
+	});
 	const navigate = useNavigate();
 
 	const handleStartClick = () => {
 		resetSfen();
+		if (selected.turn === "random") {
+			setTurn(Math.random() < 0.5 ? Color.Black : Color.White);
+		} else {
+			setTurn(selected.turn);
+		}
 		navigate("/game");
 	};
 	const handleRestoreClick = () => {
@@ -17,6 +35,27 @@ const Home = () => {
 	return (
 		<div className={styles.container}>
 			<h1 className={styles.title}>Bらm 将棋 AI</h1>
+			<div className={styles["segmented-control"]}>
+				{options.map((option) => (
+					<>
+						<input
+							key={`${option.value}-input`}
+							type="radio"
+							name="color"
+							id={option.value}
+							checked={selected.turn === option.value}
+							onChange={() => {
+								setSelected({ turn: option.value });
+							}}
+						/>
+						<label key={`${option.value}-label`} htmlFor={option.value}>
+							<span>{option.label}</span>
+						</label>
+					</>
+				))}
+				<span className={styles.slider} />
+			</div>
+
 			<button
 				type="button"
 				className={styles.button}
@@ -24,6 +63,9 @@ const Home = () => {
 			>
 				対局開始
 			</button>
+
+			<span className={styles.divider}>または</span>
+
 			<button
 				type="button"
 				className={styles.button}

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -18,14 +18,17 @@
 	--color-hover: #df6722;
 
 	position: relative;
-	width: 400px;
+	width: min(400px, 80%);
 	height: 48px;
 	border: none;
-	border-radius: 8px;
+	border-radius: 12px;
 	font-size: 1.2em;
+	font-weight: bold;
+	color: #000;
 	background-color: var(--color);
 	box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.4);
 	overflow: hidden;
+	cursor: pointer;
 	transition: 1s;
 
 	&:hover {
@@ -39,7 +42,6 @@
 
 	&::before {
 		content: "";
-
 		position: absolute;
 		left: 0;
 		top: 0;
@@ -63,4 +65,87 @@
 
 		transition: 1s;
 	}
+}
+
+/*
+ * Segmented Control
+ */
+
+.segmented-control {
+	display: flex;
+	flex-direction: row;
+
+	justify-content: center;
+	align-items: center;
+	position: relative;
+	width: min(400px, 80%);
+	height: 50px;
+	padding: 4px;
+	border-radius: 12px;
+	box-sizing: border-box;
+	box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.4);
+	overflow: hidden;
+	background-color: #cecece;
+	cursor: pointer;
+}
+
+.segmented-control input[type="radio"] {
+	display: none;
+}
+
+.segmented-control label {
+	width: 100%;
+	text-align: center;
+	font-size: 1.2em;
+	font-weight: bold;
+	color: #6d6d6d;
+	z-index: 2;
+	transition: 0.5s;
+}
+
+.segmented-control input[type="radio"]:checked + label {
+	color: #ffffff;
+}
+
+.slider {
+	position: absolute;
+	top: 4px;
+	left: 4px;
+	width: calc(100% / 3 - 8px);
+	height: calc(100% - 8px);
+	background-color: #df6722;
+	border-radius: 8px;
+	transition: ease 0.5s;
+}
+
+.segmented-control input[type="radio"]:nth-child(1):checked ~ .slider {
+	transform: translateX(0%);
+}
+
+.segmented-control input[type="radio"]:nth-child(3):checked ~ .slider {
+	transform: translateX(calc(100% + 8px));
+}
+
+.segmented-control input[type="radio"]:nth-child(5):checked ~ .slider {
+	transform: translateX(calc(200% + 16px));
+}
+
+/*
+ * Divider
+ */
+
+.divider {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	width: min(400px, 80%);
+	align-items: center;
+	color: #6d6d6d;
+}
+
+.divider::before,
+.divider::after {
+	content: "";
+	flex: 1;
+	border-bottom: 1px solid #828282;
 }


### PR DESCRIPTION
## 変更点

- 先手後手を選択するためのセグメントコントロールの追加
- 将棋盤を先手後手に合わせて回転


## スクリーンショット

<img width="570" alt="image" src="https://github.com/user-attachments/assets/eb2f191e-9dcf-43bb-878e-3374899dad42" />

## Issue

- #14 