### PR TITLE
feat: ゲーム終了時の処理の追加

### DIFF
--- a/src/components/ResultPop.jsx
+++ b/src/components/ResultPop.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router";
 import styles from "./ResultPop.module.css";
-const Modal = ({ showFlag, setShowFlag, result }) => {
+const ResultPop = ({ showFlag, setShowFlag, result }) => {
 	const navigate = useNavigate();
 	if (!showFlag) return null;
 
@@ -13,9 +13,9 @@ const Modal = ({ showFlag, setShowFlag, result }) => {
 	};
 	return (
 		<div className={styles.overlay}>
-			<div className={styles.modalContent}>
+			<div className={styles["modal-content"]}>
 				<h1>{result === "win" ? "勝利" : "敗北"}</h1>
-				<div className={styles.buttonContainer}>
+				<div className={styles["button-container"]}>
 					<button
 						type="button"
 						className={styles.button}
@@ -43,4 +43,4 @@ const Modal = ({ showFlag, setShowFlag, result }) => {
 	);
 };
 
-export default Modal;
+export default ResultPop;

--- a/src/components/ResultPop.jsx
+++ b/src/components/ResultPop.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useNavigate } from "react-router";
+import styles from "./ResultPop.module.css";
+const Modal = ({ showFlag, setShowFlag, result }) => {
+	const navigate = useNavigate();
+	if (!showFlag) return null;
+
+	const handleRestartClick = () => {
+		setShowFlag(false);
+	};
+	const handleHomeClick = () => {
+		navigate("/");
+	};
+	return (
+		<div className={styles.overlay}>
+			<div className={styles.modalContent}>
+				<h1>{result === "win" ? "勝利" : "敗北"}</h1>
+				<div className={styles.buttonContainer}>
+					<button
+						type="button"
+						className={styles.button}
+						onClick={() => setShowFlag(false)}
+					>
+						閉じる
+					</button>
+					{/* <button
+						type="button"
+						className={styles.button}
+						onClick={() => handleRestartClick()}
+					>
+						もう一度プレイ
+					</button> */}
+					<button
+						type="button"
+						className={styles.button}
+						onClick={() => handleHomeClick()}
+					>
+						ホーム
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Modal;

--- a/src/components/ResultPop.module.css
+++ b/src/components/ResultPop.module.css
@@ -12,8 +12,8 @@
 }
 
 .modal-content {
-	width: 30vw;
-	height: 30vh;
+	width: fit-content;
+	height: fit-content;
 	background-color: var(--color-surface-dim);
 	border-radius: 10px;
 	box-shadow: 0 0 15px var(--color-on-surface-dim);

--- a/src/components/ResultPop.module.css
+++ b/src/components/ResultPop.module.css
@@ -11,7 +11,7 @@
 	z-index: 1000; /* 前面に表示 */
 }
 
-.modalContent {
+.modal-content {
 	width: 30vw;
 	height: 30vh;
 	background-color: var(--color-surface-dim);
@@ -24,7 +24,7 @@
 	justify-content: center;
 }
 
-.buttonContainer {
+.button-container {
 	display: flex;
 	gap: 20px;
 	margin-top: 20px;

--- a/src/components/ResultPop.module.css
+++ b/src/components/ResultPop.module.css
@@ -1,0 +1,44 @@
+.overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.5); /* 半透明の背景 */
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1000; /* 前面に表示 */
+}
+
+.modalContent {
+	width: 30vw;
+	height: 30vh;
+	background-color: var(--color-surface-dim);
+	border-radius: 10px;
+	box-shadow: 0 0 15px var(--color-on-surface-dim);
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
+.buttonContainer {
+	display: flex;
+	gap: 20px;
+	margin-top: 20px;
+}
+
+.button {
+	padding: 10px 20px;
+	background-color: var(--color-primary);
+	color: var(--color-on-primary);
+	border: none;
+	border-radius: 5px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 150px;
+}

--- a/src/hooks/useGameStatus.js
+++ b/src/hooks/useGameStatus.js
@@ -1,0 +1,15 @@
+import { useLocalStorage } from "react-use";
+import { Color } from "shogi.js";
+
+const GameStatus = {
+	PLAY: "play",
+	WIN: "win",
+	LOSE: "lose",
+};
+
+function useGameStatus() {
+	return useLocalStorage("gameStatus", GameStatus.PLAY);
+}
+
+export default useGameStatus;
+export { GameStatus };

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Color, Piece, Shogi } from "shogi.js";
 import HandSummary from "../components/HandSummary";
 import Header from "../components/Header";
-import Modal from "../components/ResultPop";
+import ResultPop from "../components/ResultPop";
 import ShogiBoard from "../components/ShogiBoard";
 import useSfen from "../hooks/useSfen";
 import useTurn from "../hooks/useTurn";
@@ -27,7 +27,7 @@ const Game = () => {
 	const [sfen, setSfen] = useSfen();
 	const [turn, setTurn] = useTurn();
 	const [selected, setSelected] = useState(initialSelectedState);
-	const [gameState, setgameState] = useState(gameStatus.PLAY);
+	const [gameState, setGameState] = useState(gameStatus.PLAY);
 	const shogi = useMemo(() => shogiFromSfen(sfen), [sfen]);
 	const [showModal, setShowModal] = useState(false);
 
@@ -40,7 +40,7 @@ const Game = () => {
 				.then((response) => {
 					const nextSfen = response.data.message;
 					const status = response.data.status;
-					setgameState(status);
+					setGameState(status);
 					setSfen(nextSfen);
 				})
 				.catch((error) => {
@@ -151,7 +151,7 @@ const Game = () => {
 	return (
 		<div className="container">
 			<Header onCopySfenClick={handleCopyClick} />
-			<Modal
+			<ResultPop
 				showFlag={showModal}
 				setShowFlag={setShowModal}
 				result={gameState}

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -5,6 +5,7 @@ import HandSummary from "../components/HandSummary";
 import Header from "../components/Header";
 import ResultPop from "../components/ResultPop";
 import ShogiBoard from "../components/ShogiBoard";
+import useGameStatus, { GameStatus } from "../hooks/useGameStatus";
 import useSfen from "../hooks/useSfen";
 import useTurn from "../hooks/useTurn";
 import { shogiFromSfen } from "../utils";
@@ -17,17 +18,12 @@ const initialSelectedState = {
 	y: null, // 1-9 | null
 	moves: [], // IMove[]
 };
-const gameStatus = {
-	PLAY: "play",
-	WIN: "win",
-	LOSE: "lose",
-};
 
 const Game = () => {
 	const [sfen, setSfen] = useSfen();
 	const [turn, setTurn] = useTurn();
 	const [selected, setSelected] = useState(initialSelectedState);
-	const [gameState, setGameState] = useState(gameStatus.PLAY);
+	const [gameStatus, setGameStatus] = useGameStatus(GameStatus.PLAY);
 	const shogi = useMemo(() => shogiFromSfen(sfen), [sfen]);
 	const [showModal, setShowModal] = useState(false);
 
@@ -40,23 +36,23 @@ const Game = () => {
 				.then((response) => {
 					const nextSfen = response.data.message;
 					const status = response.data.status;
-					setGameState(status);
+					setGameStatus(status);
 					setSfen(nextSfen);
 				})
 				.catch((error) => {
 					console.error("Error sending data:", error);
 				});
 		}
-	}, [shogi, setSfen, turn]);
+	}, [shogi, setSfen, turn, setGameStatus]);
 
 	useEffect(() => {
-		if (gameState !== gameStatus.PLAY) {
+		if (gameStatus !== GameStatus.PLAY) {
 			setShowModal(true);
 		}
-	}, [gameState]);
+	}, [gameStatus]);
 
 	const handleBoardClick = (x, y) => {
-		if (gameState !== gameStatus.PLAY) {
+		if (gameStatus !== GameStatus.PLAY) {
 			return;
 		}
 		if (shogi.turn !== turn) {
@@ -154,7 +150,7 @@ const Game = () => {
 			<ResultPop
 				showFlag={showModal}
 				setShowFlag={setShowModal}
-				result={gameState}
+				result={gameStatus}
 			/>
 			<div
 				className={styles.container}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Color } from "shogi.js";
 import ThemeToggleButton from "../components/ThemeToggleButton";
+import useGameStatus, { GameStatus } from "../hooks/useGameStatus";
 import useSfen from "../hooks/useSfen";
 import useTurn from "../hooks/useTurn";
 import styles from "./Home.module.css";
@@ -15,6 +16,7 @@ const options = [
 const Home = () => {
 	const [sfen, setSfen, resetSfen] = useSfen();
 	const [turn, setTurn] = useTurn();
+	const [gameStatus, setGameStatus] = useGameStatus();
 	const [selected, setSelected] = useState({
 		turn: Color.Black,
 	});
@@ -27,6 +29,7 @@ const Home = () => {
 		} else {
 			setTurn(selected.turn);
 		}
+		setGameStatus(GameStatus.PLAY);
 		navigate("/game");
 	};
 	const handleRestoreClick = () => {


### PR DESCRIPTION
#19
- リザルト画面の追加
- サーバからsfenを受け取る際にstatusを受け取り、win,loseならリザルト画面を表示
- ゲーム終了後は駒の移動を停止